### PR TITLE
Allow multiple batch inbox addresses

### DIFF
--- a/src/map_filter_op_batch_inbox_transactions.rs
+++ b/src/map_filter_op_batch_inbox_transactions.rs
@@ -4,27 +4,17 @@ use substreams::Hex;
 use substreams_ethereum::pb::eth::v2::Block;
 
 #[derive(Debug, Deserialize)]
-struct Params {
-	op_batch_inbox: String
+struct FilterParams {
+	op_batch_inbox_addresses: Vec<String>
 }
 
 #[substreams::handlers::map]
 fn map_filter_op_batch_inbox_transactions(params: String, blk: Block) -> Result<ListOfOpBatchInboxCallData, Vec<substreams::errors::Error>> {
-	// Parse the query string parameters safely
-	let query: Params = match serde_qs::from_str(&params) {
-		Ok(query) => query,
-		Err(_) => return Err(vec![substreams::errors::Error::msg("Failed to parse query parameters")]),
-	};
-
-	// Decode the op_batch_inbox address
-	let op_batch_inbox_address = match Hex::decode(&query.op_batch_inbox) {
-			Ok(addr) => addr,
-			Err(_) => return Err(vec![substreams::errors::Error::msg("Failed to decode op_batch_inbox address")]),
-	};
+	let decoded_addresses = filters_from_params(params)?;
 
 	let data: Vec<OpBatchInboxCallData> = blk
 		.transaction_traces.iter()
-		.filter(|tx| tx.to == op_batch_inbox_address)
+		.filter(|tx| decoded_addresses.iter().any(|addr| &tx.to == addr))
 		.map(|tx| OpBatchInboxCallData {
 			tx_hash: Hex::encode(&tx.hash),
 			batcher_address: Hex::encode(&tx.from),
@@ -35,4 +25,25 @@ fn map_filter_op_batch_inbox_transactions(params: String, blk: Block) -> Result<
 		.collect();
 
 	Ok(ListOfOpBatchInboxCallData { data })
+}
+
+fn filters_from_params(params: String) -> Result<Vec<Vec<u8>>, Vec<substreams::errors::Error>> {
+	// Parse the query string parameters safely
+	let query: FilterParams = match serde_qs::from_str(&params) {
+		Ok(query) => query,
+		Err(_) => return Err(vec![substreams::errors::Error::msg("Failed to parse input parameters")]),
+	};
+
+	// Decode the op_batch_inbox address
+	let mut decoded_addresses = Vec::new();
+
+	for address in &query.op_batch_inbox_addresses {
+		let decoded_address = match Hex::decode(address) {
+			Ok(addr) => addr,
+			Err(_) => return Err(vec![substreams::errors::Error::msg("Failed to decode op_batch_inbox_addresses")]),
+		};
+		decoded_addresses.push(decoded_address);
+	}
+
+	Ok(decoded_addresses)
 }

--- a/substreams.yaml
+++ b/substreams.yaml
@@ -100,4 +100,4 @@ network: mainnet
 networks:
   mainnet:
     params:
-      map_filter_op_batch_inbox_transactions: "op_batch_inbox=ff00000000000000000000000000000000000010"
+      map_filter_op_batch_inbox_transactions: "op_batch_inbox_addresses[]=ff00000000000000000000000000000000000010&"


### PR DESCRIPTION
This change makes it possible to easily add a new OP Batch Inbox address to be tracked by our substreams package.